### PR TITLE
checkboxes in advanced search form for substring matching

### DIFF
--- a/htdocs/advancedsearch.php
+++ b/htdocs/advancedsearch.php
@@ -52,7 +52,11 @@ if ($result === "") {
             else {
                 if (isset($_POST[$item]) and $_POST[$item]) {
                     $value = $_POST[$item];
-                    $value = ldap_escape($value, "*", LDAP_ESCAPE_FILTER);
+                    if (isset($_POST[$item."match"]) and ($_POST[$item."match"] == 'sub')) {
+                        $value = '*' . ldap_escape($value, "", LDAP_ESCAPE_FILTER) . '*';
+                    } else {
+                        $value = ldap_escape($value, "*", LDAP_ESCAPE_FILTER);
+                    }
                     $ldap_filter .= "($attribute=$value)";
                 }
             }

--- a/htdocs/css/white-pages.css
+++ b/htdocs/css/white-pages.css
@@ -27,3 +27,7 @@ img.logo {
   margin-bottom: 20px;
 }
 
+.input-group-addon label {
+  margin: 0;
+  font-weight: normal;
+}

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -47,6 +47,7 @@ $messages['notdefined'] = "Not defined";
 $messages['search'] = "Search";
 $messages['searchrequired'] = "Please enter your search";
 $messages['sizelimit'] = "Size limit has been reached, some entries could not be displayed";
+$messages['submatch'] = "contains";
 $messages['title'] = "White Pages";
 $messages['todate'] = "To";
 $messages['true'] = "Yes";

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -47,6 +47,7 @@ $messages['notdefined'] = "Non renseigné";
 $messages['search'] = "Rechercher";
 $messages['searchrequired'] = "Veuillez saisir votre recherche";
 $messages['sizelimit'] = "La limite de recherche a été atteinte, certaines entrées n'ont pas pu être affichées";
+$messages['submatch'] = "contient";
 $messages['title'] = "Pages blanches";
 $messages['todate'] = "Jusqu'au";
 $messages['true'] = "Oui";

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -47,6 +47,7 @@ $messages['notdefined'] = "Non definito";
 $messages['search'] = "Cerca";
 $messages['searchrequired'] = "Inserisci il termine di ricerca";
 $messages['sizelimit'] = "Limite dimensioni raggiunto, alcuni record non saranno visualizzati";
+$messages['submatch'] = "contiene";
 $messages['title'] = "White Pages";
 $messages['todate'] = "A";
 $messages['true'] = "Si";

--- a/templates/search_displayer.tpl
+++ b/templates/search_displayer.tpl
@@ -16,6 +16,7 @@
             <input type="text" class="form-control" id="{$item}to" name="{$item}to" data-provide="datepicker" data-date-language="{$lang}">
             {else}
             <input type="text" class="form-control" id="{$item}" name="{$item}" placeholder="{$label}">
+            <span class="input-group-addon"><label><input type="checkbox" name="{$item}match" value="sub"> {$msg_submatch}</label></span>
             {/if}
         </div>
     </div>


### PR DESCRIPTION
Can resolve #18 

- by default, advanced search is still using exact matching and can accept wildcard in search pattern
- a checkbox is available on each search field to suggest a substring matching for this value
- checking this option will just automatically add wildcards before and after the search value
- it's easier to use for people who don't know that they can add wildcard with exact matching