### PR TITLE
Filter in place of Search + non-breaking space

### DIFF
--- a/htdocs/vendor/datatables/i18n/en.json
+++ b/htdocs/vendor/datatables/i18n/en.json
@@ -10,7 +10,7 @@
 	"sLengthMenu":     "Show _MENU_ entries",
 	"sLoadingRecords": "Loading...",
 	"sProcessing":     "Processing...",
-	"sSearch":         "Search:",
+	"sSearch":         "Filter&nbsp;:",
 	"sZeroRecords":    "No matching records found",
 	"oPaginate": {
 		"sFirst":    "First",

--- a/htdocs/vendor/datatables/i18n/fr.json
+++ b/htdocs/vendor/datatables/i18n/fr.json
@@ -2,7 +2,7 @@
 
 {
 	"sProcessing":     "Traitement en cours...",
-	"sSearch":         "Rechercher&nbsp;:",
+	"sSearch":         "Filtrer&nbsp;:",
     "sLengthMenu":     "Afficher _MENU_ &eacute;l&eacute;ments",
 	"sInfo":           "Affichage de l'&eacute;l&eacute;ment _START_ &agrave; _END_ sur _TOTAL_ &eacute;l&eacute;ments",
 	"sInfoEmpty":      "Affichage de l'&eacute;l&eacute;ment 0 &agrave; 0 sur 0 &eacute;l&eacute;ment",

--- a/htdocs/vendor/datatables/i18n/it.json
+++ b/htdocs/vendor/datatables/i18n/it.json
@@ -10,7 +10,7 @@
 	"sLengthMenu":     "Visualizza _MENU_ elementi",
 	"sLoadingRecords": "Caricamento...",
 	"sProcessing":     "Elaborazione...",
-	"sSearch":         "Cerca:",
+	"sSearch":         "Filtro&nbsp;:",
 	"sZeroRecords":    "La ricerca non ha portato alcun risultato.",
 	"oPaginate": {
 		"sFirst":      "Inizio",


### PR DESCRIPTION
Linked to #25 

Filter is more consistent than Search :  word "filter" was already use in : https://github.com/ltb-project/white-pages/blob/8f63681936f963ef8b69eb50de09e37f7de280c4/htdocs/vendor/datatables/i18n/en.json#L7

I also add non-breaking space for EN and IT translation.