### PR TITLE
Directory view enhancement

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -97,6 +97,7 @@ $use_directory = true;
 $directory_items = array('firstname', 'lastname', 'mail', 'organization');
 $directory_linkto = array('firstname', 'lastname');
 $directory_sortby = "lastname";
+$default_page_length = 10;  // 10, 25, 50, 100 or -1 for all
 
 # CSV
 $use_csv = true;

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -95,6 +95,7 @@ $gallery_truncate_title_after = "25";
 # Directory
 $use_directory = true;
 $directory_items = array('firstname', 'lastname', 'mail', 'organization');
+$directory_linkto = array('firstname', 'lastname');
 $directory_sortby = "lastname";
 
 # CSV

--- a/htdocs/css/white-pages.css
+++ b/htdocs/css/white-pages.css
@@ -42,3 +42,9 @@ table.dataTable thead .sorting_desc_disabled::after {
   margin-left: 8px;
 }
 
+@media print {
+  a[href]:after {
+  /*content: " (" attr(href) ")";*/
+    content: none;
+  }
+}

--- a/htdocs/css/white-pages.css
+++ b/htdocs/css/white-pages.css
@@ -31,3 +31,14 @@ img.logo {
   margin: 0;
   font-weight: normal;
 }
+
+table.dataTable thead .sorting::after,
+table.dataTable thead .sorting_asc::after,
+table.dataTable thead .sorting_desc::after,
+table.dataTable thead .sorting_asc_disabled::after,
+table.dataTable thead .sorting_desc_disabled::after {
+  position: initial;
+  display:  inline;
+  margin-left: 8px;
+}
+

--- a/htdocs/directory.php
+++ b/htdocs/directory.php
@@ -58,6 +58,7 @@ $smarty->assign("nb_entries", $nb_entries);
 $smarty->assign("entries", $entries);
 $smarty->assign("size_limit_reached", $size_limit_reached);
 $smarty->assign("columns", $directory_items);
+$smarty->assign("linkto", $directory_linkto);
 $smarty->assign("sortby", $sortidx);
 
 ?>

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -57,6 +57,7 @@ $smarty->assign('search_result_truncate_title_after',$search_result_truncate_tit
 $smarty->assign('use_advanced_search',$use_advanced_search);
 $smarty->assign('advanced_search_criteria',$advanced_search_criteria);
 $smarty->assign('results_display_mode',$results_display_mode);
+$smarty->assign('default_page_length',$default_page_length);
 $smarty->assign('display_items',$display_items);
 $smarty->assign('display_title',$display_title);
 $smarty->assign('use_directory',$use_directory);
@@ -92,6 +93,7 @@ $page = "welcome";
 if (isset($_GET["page"]) and $_GET["page"]) { $page = $_GET["page"]; }
 if ( $page === "search" and !$use_quick_search ) { $page = "welcome"; }
 if ( $page === "advancedsearch" and !$use_advanced_search ) { $page = "welcome"; }
+if ( $page === "directory" and !$use_directory ) { $page = "welcome"; }
 if ( $page === "gallery" and !$use_gallery ) { $page = "welcome"; }
 if ( file_exists($page.".php") ) { require_once($page.".php"); }
 $smarty->assign('page',$page);

--- a/templates/directory.tpl
+++ b/templates/directory.tpl
@@ -13,9 +13,19 @@
 <tbody>
 {foreach $entries as $entry}
     <tr>
-        <th><a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}" class="btn btn-info btn-sm" role="button" title="{$msg_displayentry}"><i class="fa fa-fw fa-id-card"></i></a></th>
+        <th><a href="index.php?page=display&dn={$entry.dn|escape:'url'}" class="btn btn-info btn-sm" role="button" title="{$msg_displayentry}"><i class="fa fa-fw fa-id-card"></i></a></th>
     {foreach $columns as $column}
-        <td>{$entry.{$attributes_map.{$column}.attribute}.0}</td>
+        <td>
+        {$attribute=$attributes_map.{$column}.attribute}
+        {if !({$entry.$attribute.0})}
+            &mdash;{continue}
+        {/if}
+        {foreach $entry.{$attribute} as $value}
+            {if $value@index eq 0}{continue}{/if}
+            {$type=$attributes_map.{$column}.type}
+            {include 'value_displayer.tpl' value=$value type=$type truncate_value_after=$search_result_truncate_value_after ldap_params=$ldap_params date_specifiers=$date_specifiers}<br />
+        {/foreach}
+        </td>
     {/foreach}
     </tr>
 {/foreach}

--- a/templates/directory.tpl
+++ b/templates/directory.tpl
@@ -20,11 +20,17 @@
         {if !({$entry.$attribute.0})}
             &mdash;{continue}
         {/if}
+        {if in_array($column, $linkto)}
+             <a href="index.php?page=display&dn={$entry.dn|escape:'url'}" title="{$msg_displayentry}">
+        {/if}
         {foreach $entry.{$attribute} as $value}
             {if $value@index eq 0}{continue}{/if}
             {$type=$attributes_map.{$column}.type}
             {include 'value_displayer.tpl' value=$value type=$type truncate_value_after=$search_result_truncate_value_after ldap_params=$ldap_params date_specifiers=$date_specifiers}<br />
         {/foreach}
+        {if in_array($column, $linkto)}
+             </a>
+        {/if}
         </td>
     {/foreach}
     </tr>

--- a/templates/footer.tpl
+++ b/templates/footer.tpl
@@ -17,14 +17,18 @@
           "paging":       true,
           "info":         true,
           "processing":   true,
+          "pageLength":   {/literal}{$default_page_length|default:10}{literal},
+          "lengthMenu": [
+            [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]
+          ],
           "order": [
-            [ {/literal}{$sortby + 1}{literal}, "asc" ]
+            [ {/literal}{$sortby|default:0 + 1}{literal}, "asc" ]
           ],
           "aoColumnDefs": [
             { "bSortable": false, "aTargets": ['nosort'] },
           ],
           "language": {
-            "url": "vendor/datatables/i18n/{/literal}{$lang}{literal}.json"
+            "url": "vendor/datatables/i18n/{/literal}{$lang|default:'en'}{literal}.json"
           }
         });
       });


### PR DESCRIPTION
Following #25 

>    sort icons should be more close than their column name to avoid sorting on bad column name

Done (adjustment in css)

>    no tel: or mail: links for each row (in comparison with quick/advanced search results)

Done (using same code already made for search results)

>    link on each row to display entry : will be nice to have a clickable row rather than an icon. Not so easy because we need to keep tel: and mail: links. Maybe a link on firstname/lastname.

Done (see new config option $directory_linkto)

>    generalize display/pagination to quick/advanced search with rows (as @coudot said)

Todo (not related to this part, see #1)

>    number of elements display on pages :
        add a PHP option to set default number (currently = 10)

Done (see new config option $default_page_length)

>    number of elements display on pages :
        add additional values in dropdown : "all" and/or an input field to enter a number (for example : 250)

Done (with value -1 for All)

>    print preview is not usuable

Done, i think, the problem reported is unclear...
I see that with the print css, all URL (href) are displayed and it's not very convenient. This came with default bootstrap CSS. I have added a css definition to remove this fonctionality.
