### PR TITLE
Fix Groups Rendering, when Groups and Users base DN are the same

### DIFF
--- a/htdocs/advancedsearch.php
+++ b/htdocs/advancedsearch.php
@@ -40,6 +40,8 @@ if (!isset($_POST["submit"])) {
 
 if (isset($_POST["type"])) {
     $type = $_POST["type"];
+} else if (isset($_GET["type"])) {
+    $type = $_GET["type"];
 }
 
 if ( $type === "user" ) {
@@ -183,7 +185,7 @@ if ($result === "") {
                 $smarty->assign("nb_entries", $nb_entries);
                 $smarty->assign("entries", $entries);
                 $smarty->assign("size_limit_reached", $size_limit_reached);
-                $smarty->assign("type", $type);
+                $smarty->assign("objecttype", $type);
 
                 if ($results_display_mode == 'table') {
                     $columns = $result_items;

--- a/htdocs/advancedsearch.php
+++ b/htdocs/advancedsearch.php
@@ -74,8 +74,8 @@ if ($result === "") {
         $ldap_filter = "(&".$ldap_search_filter."(&";
         foreach ($advanced_search_criteria as $item) {
             $attribute = $attributes_map[$item]['attribute'];
-            $type = $attributes_map[$item]['type'];
-            if ( $type == "date") {
+            $kind = $attributes_map[$item]['type'];
+            if ( $kind == "date") {
                 if (isset($_POST[$item."from"]) and $_POST[$item."from"]) {
                     $value = string2ldapDate($_POST[$item."from"]);
                     $value = ldap_escape($value, null, LDAP_ESCAPE_FILTER);
@@ -87,7 +87,7 @@ if ($result === "") {
                     $ldap_filter .= "($attribute<=$value)";
                 }
             }
-            elseif ( $type == "boolean") {
+            elseif ( $kind == "boolean") {
                 if (isset($_POST[$item]) and $_POST[$item]) {
                     $value = $_POST[$item];
                     $value = ldap_escape($value, null, LDAP_ESCAPE_FILTER);

--- a/htdocs/directory.php
+++ b/htdocs/directory.php
@@ -17,7 +17,9 @@ $ldap_connection = wp_ldap_connect($ldap_url, $ldap_starttls, $ldap_binddn, $lda
 $ldap = $ldap_connection[0];
 $result = $ldap_connection[1];
 
-if (isset($_GET["type"])) {
+if (isset($_POST['type'])) {
+    $type = $_POST['type'];
+} else if (isset($_GET["type"])) {
     $type = $_GET["type"];
 } else {
     $type = "user";
@@ -86,6 +88,6 @@ $smarty->assign("listing_sortby", array_search($result_sortby, $result_items));
 $smarty->assign("show_undef", $directory_show_undefined);
 $smarty->assign("truncate_value_after", $directory_truncate_value_after);
 
-$smarty->assign("type", $type);
+$smarty->assign("objecttype", $type);
 $smarty->assign("directory_display_search_objects", $directory_display_search_objects)
 ?>

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -31,6 +31,8 @@ if ($result === "") {
     # Find object type
     if (isset($_POST['type'])) {
         $type = $_POST['type'];
+    } else if (isset($_GET["type"])) {
+	$type = $_GET["type"];
     } else if (isset($ldap_user_regex)) {
         if ( preg_match( $ldap_user_regex, $dn) ) {
             $type = "user";
@@ -40,8 +42,7 @@ if ($result === "") {
     } else {
         if ( preg_match( '/'.$ldap_user_base.'$/i', $dn) ) {
             $type = "user";
-        }
-        else {
+        } else {
             $type = "group";
         }
     }
@@ -58,7 +59,7 @@ if ($result === "") {
         }
         $attributes[] = $attributes_map[$display_title]['attribute'];
 
-        if ($use_vcard and $_GET["vcard"] and $vcard_file_identifier) {
+        if ($use_vcard and isset($_GET["vcard"]) and $vcard_file_identifier) {
             $attributes[] = $attributes_map[$vcard_file_identifier]['attribute'];
 	}
 
@@ -89,7 +90,7 @@ if ($result === "") {
             $entry[0][$attr] = $values;
         }
 
-	if ($use_vcard and $_GET["vcard"]) {
+	if ($use_vcard and isset($_GET["vcard"])) {
             require_once("../lib/vcard.inc.php");
             $vcard_file = $entry[0][$attributes_map[$vcard_file_identifier]['attribute']][0].".".$vcard_file_extension;
             download_vcard_send_headers($vcard_file);
@@ -109,7 +110,7 @@ $smarty->assign("entry", $entry[0]);
 $smarty->assign("card_title", $display_title);
 $smarty->assign("card_items", $search_items);
 $smarty->assign("show_undef", $display_show_undefined);
-$smarty->assign("type", $type);
+$smarty->assign("objecttype", $type);
 
 $smarty->assign("edit_link", $edit_link);
 ?>

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -76,7 +76,7 @@ if ($use_datatables) {
 }
 $smarty->assign('version',$version);
 $smarty->assign('display_footer',$display_footer);
-$smarty->assign('logout_link',$logout_link);
+$smarty->assign('logout_link', (isset($logout_link) ? $logout_link : false));
 
 # Assign messages
 $smarty->assign('lang',$lang);

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -81,6 +81,7 @@ if ($result === "") {
                 $smarty->assign("nb_entries", $nb_entries);
                 $smarty->assign("entries", $entries);
                 $smarty->assign("size_limit_reached", $size_limit_reached);
+		$smarty->assign("objecttype", "user");
 
                 if ($results_display_mode == 'table') {
                     $columns = $search_result_items;

--- a/templates/directory.tpl
+++ b/templates/directory.tpl
@@ -9,8 +9,8 @@
 
 {if {$directory_display_search_objects}}
 <div class="btn-group" role="group">
-  <a type="button" href="index.php?page=directory&type=user" class="btn btn-default{if {$type}==="user"} active{/if}"><i class="fa fa-user"></i> {$msg_user_object}</a>
-  <a type="button" href="index.php?page=directory&type=group" class="btn btn-default{if {$type}==="group"} active{/if}"><i class="fa fa-group"></i> {$msg_group_object}</a>
+  <a type="button" href="index.php?page=directory&type=user" class="btn btn-default{if {$objecttype}==="user"} active{/if}"><i class="fa fa-user"></i> {$msg_user_object}</a>
+  <a type="button" href="index.php?page=directory&type=group" class="btn btn-default{if {$objecttype}==="group"} active{/if}"><i class="fa fa-group"></i> {$msg_group_object}</a>
 </div>
 <hr />
 {/if}

--- a/templates/display.tpl
+++ b/templates/display.tpl
@@ -12,7 +12,7 @@
 
             <div class="panel-body">
 
-                {if $type === "user"}
+                {if $objecttype === "user"}
                 <img src="photo.php?dn={$entry.dn|escape:'url'}" alt="{$entry.{$attributes_map.{$card_title}.attribute}.0}" class="img-responsive img-thumbnail center-block" />
                 {/if}
 
@@ -51,7 +51,7 @@
 {if {$use_vcard} || {$edit_link}}
             <div class="panel-footer text-center">
 {if {$use_vcard}}
-                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}&vcard=1" class="btn btn-info" role="button"><i class="fa fa-fw fa-download"></i> {$msg_downloadvcard}</a>
+                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}&type={$objecttype}&vcard=1" class="btn btn-info" role="button"><i class="fa fa-fw fa-download"></i> {$msg_downloadvcard}</a>
 {/if}
 {if {$edit_link}}
                 <a href="{$edit_link}" class="btn btn-info" role="button"><i class="fa fa-fw fa-edit"></i> {$msg_editentry}</a>

--- a/templates/gallery.tpl
+++ b/templates/gallery.tpl
@@ -12,7 +12,7 @@
     <div class="gallery {$bootstrap_column_class}{if $hover_effect} hvr-{$hover_effect}{/if}">
         <div class="panel panel-info">
             <div class="panel-body">
-                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}">
+                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&type={$objecttype}&search={$search}">
                     <img src="photo.php?dn={$entry.dn|escape:'url'}" alt="{$entry.{$attributes_map.{$card_title}.attribute}.0}" class="img-responsive img-thumbnail center-block" />
                 </a>
             </div>

--- a/templates/listing_boxes.tpl
+++ b/templates/listing_boxes.tpl
@@ -11,7 +11,7 @@
             <div class="panel-body">
             <div class="row">
             <div class="col-sm-4">
-                {if {$type}==="user"}<img src="photo.php?dn={$entry.dn|escape:'url'}" alt="{$entry.{$attributes_map.{$card_title}.attribute}.0}" class="img-responsive img-thumbnail center-block" />{/if}
+                {if {$objecttype}==="user"}<img src="photo.php?dn={$entry.dn|escape:'url'}" alt="{$entry.{$attributes_map.{$card_title}.attribute}.0}" class="img-responsive img-thumbnail center-block" />{/if}
             </div>
             <div class="col-sm-8">
             {foreach $card_items as $item}
@@ -34,7 +34,7 @@
             </div>
             </div>
             <div class="panel-footer text-center">
-                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}" class="btn btn-info" role="button"><i class="fa fa-fw fa-id-card"></i> {$msg_displayentry}</a>
+                <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&type={$objecttype}&search={$search}" class="btn btn-info" role="button"><i class="fa fa-fw fa-id-card"></i> {$msg_displayentry}</a>
             </div>
         </div>
     </div>

--- a/templates/listing_table.tpl
+++ b/templates/listing_table.tpl
@@ -6,14 +6,13 @@
     </tr>
 </thead>
 <tbody>
-{$ldap_object_type=$type}
 {foreach $entries as $entry}
     <tr{if ! $listing_linkto|is_array} class="clickable" title="{$msg_displayentry}"{/if}>
         <th class="hidden-print">
-            <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}" class="btn btn-info btn-sm{if $listing_linkto===false} hidden{/if}" role="button" title="{$msg_displayentry}">
+            <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&type={$objecttype}&search={$search}" class="btn btn-info btn-sm{if $listing_linkto===false} hidden{/if}" role="button" title="{$msg_displayentry}">
                 <i class="fa fa-fw fa-id-card"></i>
             </a>
-            {if $ldap_object_type==='group'}
+            {if $objecttype==='group'}
             <a href="index.php?page=gallery&groupdn={$entry.dn|escape:'url'}" class="btn btn-info btn-sm{if $listing_linkto===false} hidden{/if}" role="button" title="{$msg_gallery}">
                 <i class="fa fa-fw fa-address-book"></i>
             </a>
@@ -24,7 +23,7 @@
         {$attribute=$attributes_map.{$column}.attribute}
         {if ({$entry.$attribute.0})}
             {if $listing_linkto|is_array && in_array($column, $listing_linkto)}
-                 <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&search={$search}" title="{$msg_displayentry}">
+                 <a href="index.php?page=display&dn={$entry.dn|escape:'url'}&type={$objecttype}&search={$search}" title="{$msg_displayentry}">
             {/if}
             {foreach $entry.{$attribute} as $value}
                 {if $value@index eq 0}{continue}{/if}

--- a/templates/value_displayer.tpl
+++ b/templates/value_displayer.tpl
@@ -13,21 +13,21 @@
 {if $type eq 'dn_link'}
     {assign var="link" value="{{get_attribute dn="{$value}" attribute="cn" ldap_url="{$ldap_params.ldap_url}" ldap_starttls="{$ldap_params.ldap_starttls}" ldap_binddn="{$ldap_params.ldap_binddn}" ldap_bindpw="{$ldap_params.ldap_bindpw}" ldap_filter="{$ldap_params.ldap_user_filter}" ldap_network_timeout="{$ldap_params.ldap_network_timeout}"}|truncate:{$truncate_value_after}}"}
     {if $link}
-    <a href="index.php?page=display&dn={$value|escape:'url'}&search={$search}">{$link}</a><br />
+    <a href="index.php?page=display&dn={$value|escape:'url'}&type={$objecttype}&search={$search}">{$link}</a><br />
     {/if}
 {/if}
 
 {if $type eq 'group_dn_link'}
     {assign var="link" value="{{get_attribute dn="{$value}" attribute="cn,description" ldap_url="{$ldap_params.ldap_url}" ldap_starttls="{$ldap_params.ldap_starttls}" ldap_binddn="{$ldap_params.ldap_binddn}" ldap_bindpw="{$ldap_params.ldap_bindpw}" ldap_filter="{$ldap_params.ldap_group_filter}" ldap_network_timeout="{$ldap_params.ldap_network_timeout}"}|truncate:{$truncate_value_after}}"}
     {if $link}
-    <a href="index.php?page=display&dn={$value|escape:'url'}&search={$search}">{$link}</a><br />
+    <a href="index.php?page=display&dn={$value|escape:'url'}&type={$objecttype}&search={$search}">{$link}</a><br />
     {/if}
 {/if}
 
 {if $type eq 'usergroup_dn_link'}
     {assign var="link" value="{{get_attribute dn="{$value}" attribute="cn,description" ldap_url="{$ldap_params.ldap_url}" ldap_starttls="{$ldap_params.ldap_starttls}" ldap_binddn="{$ldap_params.ldap_binddn}" ldap_bindpw="{$ldap_params.ldap_bindpw}" ldap_filter="(|{$ldap_params.ldap_group_filter}{$ldap_params.ldap_user_filter})" ldap_network_timeout="{$ldap_params.ldap_network_timeout}"}|truncate:{$truncate_value_after}}"}
     {if $link}
-    <a href="index.php?page=display&dn={$value|escape:'url'}&search={$search}">{$link}</a><br />
+    <a href="index.php?page=display&dn={$value|escape:'url'}&type={$objecttype}&search={$search}">{$link}</a><br />
     {/if}
 {/if}
 


### PR DESCRIPTION
When Users and Groups share the same base DN, we can find cases where group entries are rendered as users.
Enforces type transmission.