### PR TITLE
Groups Vcard

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -140,7 +140,7 @@ $use_vcard = true;
 $vcard_file_extension = "vcf";
 $vcard_file_identifier = "identifier";
 $vcard_version = "4.0";
-$vcard_map = array('FN' => 'fullname', 'N' => 'fullname', 'EMAIL' => 'mail', 'CATEGORIES' => 'businesscategory', 'ORG' => 'organization', 'ROLE' => 'employeetype', 'TEL;TYPE=work,voice;VALUE=uri:tel' => 'phone', 'TEL;TYPE=cell,voice;VALUE=uri:tel' => 'mobile', 'UID' => 'identifier');
+$vcard_map = array('FN' => 'fullname', 'N' => 'fullname', 'EMAIL' => 'mail', 'CATEGORIES' => 'businesscategory', 'MEMBER' => 'member', 'ORG' => 'organization', 'ROLE' => 'employeetype', 'TEL;TYPE=work,voice;VALUE=uri:tel' => 'phone', 'TEL;TYPE=cell,voice;VALUE=uri:tel' => 'mobile', 'UID' => 'identifier');
 
 # Photo
 $use_gravatar = false;

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -140,7 +140,8 @@ $use_vcard = true;
 $vcard_file_extension = "vcf";
 $vcard_file_identifier = "identifier";
 $vcard_version = "4.0";
-$vcard_map = array('FN' => 'fullname', 'N' => 'fullname', 'EMAIL' => 'mail', 'CATEGORIES' => 'businesscategory', 'MEMBER' => 'member', 'ORG' => 'organization', 'ROLE' => 'employeetype', 'TEL;TYPE=work,voice;VALUE=uri:tel' => 'phone', 'TEL;TYPE=cell,voice;VALUE=uri:tel' => 'mobile', 'UID' => 'identifier');
+$vcard_user_map = array('FN' => 'fullname', 'N' => 'fullname', 'EMAIL' => 'mail', 'CATEGORIES' => 'businesscategory', 'ORG' => 'organization', 'ROLE' => 'employeetype', 'TEL;TYPE=work,voice;VALUE=uri:tel' => 'phone', 'TEL;TYPE=cell,voice;VALUE=uri:tel' => 'mobile', 'UID' => 'identifier');
+$vcard_group_map = array('FN' => 'fullname', 'N' => 'fullname', 'EMAIL' => 'mail', 'CATEGORIES' => 'businesscategory', 'MEMBER' => 'member', 'ORG' => 'organization', 'ROLE' => 'employeetype', 'TEL;TYPE=work,voice;VALUE=uri:tel' => 'phone', 'TEL;TYPE=cell,voice;VALUE=uri:tel' => 'mobile', 'UID' => 'identifier');
 
 # Photo
 $use_gravatar = false;

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -94,6 +94,7 @@ if ($result === "") {
             $vcard_file = $entry[0][$attributes_map[$vcard_file_identifier]['attribute']][0].".".$vcard_file_extension;
             download_vcard_send_headers($vcard_file);
 	    if ($type == "group") {
+		$vcard_map = $vcard_group_map;
 		$attributes = array();
 		$attributes[] = $attributes_map['mail']['attribute'];
 		$ldap_filter = "(".$attributes_map['memberof']['attribute']."=".$entry[0]['dn'].")";
@@ -124,6 +125,8 @@ if ($result === "") {
 		    }
 		    $entry[0]['member_mailto'] = $members;
 		}
+	    } else {
+		$vcard_map = $vcard_user_map;
 	    }
             echo print_vcard($entry[0], $attributes_map, $vcard_map, $vcard_version);
             die;

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -97,12 +97,12 @@ if ($result === "") {
 		$vcard_map = $vcard_group_map;
 		$attributes = array();
 		$attributes[] = $attributes_map['mail']['attribute'];
+		$attributes[] = $attributes_map['phone']['attribute'];
 		$ldap_filter = "(".$attributes_map['memberof']['attribute']."=".$entry[0]['dn'].")";
 		$search = ldap_search($ldap, $ldap_user_base, $ldap_filter, $attributes, 0, $ldap_size_limit);
 		$errno = ldap_errno($ldap);
 		if ( $errno == 4 ) {
-		    $size_limit_reached = true;
-		    //silent ignore / don't corrupt vcard download
+		    error_log("LDAP - VCard download hit page size limit");
 		}
 		if ( $errno != 0 and $errno != 4 ) {
 		    error_log("LDAP - Search error $errno  (".ldap_error($ldap).")");
@@ -120,6 +120,8 @@ if ($result === "") {
 			    }
 			    if (isset($item[$attributes_map['mail']['attribute']])) {
 				$members[] = 'mailto:'.$item[$attributes_map['mail']['attribute']][0];
+			    } else if (isset($item[$attributes_map['phone']['attribute']])) {
+				$members[] = 'tel:'.$item[$attributes_map['phone']['attribute']][0];
 			    }
 			}
 		    }

--- a/htdocs/display.php
+++ b/htdocs/display.php
@@ -93,6 +93,38 @@ if ($result === "") {
             require_once("../lib/vcard.inc.php");
             $vcard_file = $entry[0][$attributes_map[$vcard_file_identifier]['attribute']][0].".".$vcard_file_extension;
             download_vcard_send_headers($vcard_file);
+	    if ($type == "group") {
+		$attributes = array();
+		$attributes[] = $attributes_map['mail']['attribute'];
+		$ldap_filter = "(".$attributes_map['memberof']['attribute']."=".$entry[0]['dn'].")";
+		$search = ldap_search($ldap, $ldap_user_base, $ldap_filter, $attributes, 0, $ldap_size_limit);
+		$errno = ldap_errno($ldap);
+		if ( $errno == 4 ) {
+		    $size_limit_reached = true;
+		    //silent ignore / don't corrupt vcard download
+		}
+		if ( $errno != 0 and $errno != 4 ) {
+		    error_log("LDAP - Search error $errno  (".ldap_error($ldap).")");
+		} else {
+		    # Get search results
+		    $nb_entries = ldap_count_entries($ldap, $search);
+		    $members = array();
+		    if ($nb_entries > 0) {
+			$entries = ldap_get_entries($ldap, $search);
+			foreach ($entries as $item) {
+			    foreach ($item as $a => $v) {
+				if ( $v['count'] > 1 ) { asort($v); }
+				if ( isset($v['count']) ) { unset($v['count']); }
+				$item[$a] = $v;
+			    }
+			    if (isset($item[$attributes_map['mail']['attribute']])) {
+				$members[] = 'mailto:'.$item[$attributes_map['mail']['attribute']][0];
+			    }
+			}
+		    }
+		    $entry[0]['member_mailto'] = $members;
+		}
+	    }
             echo print_vcard($entry[0], $attributes_map, $vcard_map, $vcard_version);
             die;
         }

--- a/lib/vcard.inc.php
+++ b/lib/vcard.inc.php
@@ -9,9 +9,17 @@ function print_vcard($entry, $attributes_map, $vcard_map, $vcard_version) {
    echo "BEGIN:VCARD\n";
    echo "VERSION:$vcard_version\n";
    foreach ($vcard_map as $id => $item) {
-     $attribute = $attributes_map[$item]["attribute"];
-     if (isset($entry[$attribute])) {
-       echo $id.":".$entry[$attribute][0]."\n";
+     if ($id == "MEMBER") {
+       if (isset($entry['member_mailto'])) {
+	 foreach ($entry['member_mailto'] as $mbr) {
+	   echo $id.":".$mbr."\n";
+	 }
+       }
+     } else {
+       $attribute = $attributes_map[$item]["attribute"];
+       if (isset($entry[$attribute])) {
+	 echo $id.":".$entry[$attribute][0]."\n";
+       }
      }
    }
    echo "END:VCARD\n";

--- a/lib/vcard.inc.php
+++ b/lib/vcard.inc.php
@@ -10,6 +10,7 @@ function print_vcard($entry, $attributes_map, $vcard_map, $vcard_version) {
    echo "VERSION:$vcard_version\n";
    foreach ($vcard_map as $id => $item) {
      if ($id == "MEMBER") {
+       echo "KIND:group\n";
        if (isset($entry['member_mailto'])) {
 	 foreach ($entry['member_mailto'] as $mbr) {
 	   echo $id.":".$mbr."\n";


### PR DESCRIPTION
Vcard generation for an LDAP group currently creates a vcf that only mentions the name of our group.

The following implements group members resolution, adding corresponding mailito addresses.

Which is the "easy" way to do this.
RFC also allows for references to some kind of uuid, which would imply the final vcard should include one contact per member....