### PR TITLE
Restrict languages to php files

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -15,15 +15,8 @@ require_once("../conf/config.inc.php");
 #==============================================================================
 require_once("../lib/detectbrowserlanguage.php");
 # Available languages
-$languages = array();
-if ($handle = opendir('../lang')) {
-    while (false !== ($entry = readdir($handle))) {
-        if ($entry != "." && $entry != "..") {
-             array_push($languages, str_replace(".inc.php", "", $entry));
-        }
-    }
-    closedir($handle);
-}
+$files = glob("../lang/*.php");
+$languages = str_replace(".inc.php", "", $files);
 $lang = detectLanguage($lang, $languages);
 require_once("../lang/$lang.inc.php");
 if (file_exists("../conf/$lang.inc.php")) {


### PR DESCRIPTION
By default whites-pages will load `en.inc.php.bak`, thus crashing the
web server. Example :

```
[Fri Oct 08 09:53:29.032062 2021] [php7:warn] [pid 470725] [client 172.26.15.33:59084] PHP Warning:  require_once(../lang/fr.bak.inc.php): failed to open stream: No such file or directory in /var/www/phonebook/htdocs/index.php on line 28
[Fri Oct 08 09:53:29.032090 2021] [php7:error] [pid 470725] [client 172.26.15.33:59084] PHP Fatal error:  require_once(): Failed opening required '../lang/fr.bak.inc.php' (include_path='.:/usr/share/php') in /var/www/phonebook/htdocs/index.php on line 28
```

This fix issue #109 