### PR TITLE
Photo.php: add no_fallback parameter

### DIFF
--- a/docs/photos.rst
+++ b/docs/photos.rst
@@ -10,6 +10,14 @@ Configure which file is used as default photo :
 
     $default_photo = "images/240px-PICA.jpg";
 
+Photo endpoint
+--------------
+
+A user's photo can be queried on ``/photo.php?dn=[user's DN]``. An additionnal
+``no_fallback`` parameter can be passed to avoid falling back to a default
+picture and returning 404: ``/photo.php?no_fallback&dn=[user's DN]``. This is
+useful to eg. use an application's internal fallback image instead.
+
 LDAP attribute
 --------------
 

--- a/htdocs/photo.php
+++ b/htdocs/photo.php
@@ -74,8 +74,14 @@ else {
     $result = "dnrequired";
 }
 
-# Display default photo if any error
 if ( !$photo ) {
+    # If `no_fallback` in GET parameters, fail with 404
+    if(isset($_GET['no_fallback'])) {
+        http_response_code(404);
+        die();
+    }
+
+    # Else, display default photo if any error
     $photo = imagecreatefromjpeg($default_photo);
 }
 


### PR DESCRIPTION
This PR adds a `no_fallback` GET parameter to `photo.php`. When set, whitepages won't fall back to the default photo, but will return a 404 status code instead.

This is useful eg. to use an application's internal profile picture default instead of whitepages', when this endpoint is used for an application to retrieve the user's picture.