### PR TITLE
Check page name before any inclusion

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -179,8 +179,10 @@ if ($require_auth) {
 #==============================================================================
 if (isset($_POST["apiendpoint"])) {
     $data = array();
-    if (file_exists('api/'.$_POST["apiendpoint"].'.php')) {
-        require_once('api/'.$_POST["apiendpoint"].'.php');
+    $apiendpoint = $_POST["apiendpoint"];
+    $allowed_apiendpoints = array("search_dn");
+    if (file_exists("api/$apiendpoint.php") and in_array($apiendpoint, $allowed_apiendpoints)) {
+        require_once("api/$apiendpoint.php");
     }
     echo json_encode($data);
     exit(0);


### PR DESCRIPTION
Using `open_basedir` was not possible with Smarty:
```
[28-Nov-2025 16:23:51 UTC] PHP Warning:  is_file(): open_basedir restriction in effect. File(/usr/share/php/smarty4/libs/sysplugins/smarty_template_compiled.php) is not within the allowed path(s): (/usr/local/white-pages) in /usr/share/php/smarty4/libs/Autoloader.php on line 100
```

So I choose to only check the validity of the page name.