### PR TITLE
fix: missing volume for lang file & local changes to working dir

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,9 @@ services:
       - ./htdocs/:/var/www/htdocs/
       - ./conf/:/var/www/conf/
       - ./templates/:/var/www/templates/
-      - ./vendor/:/var/www/vendor/
+      - ./lang/:/var/www/lang/
+      - vendor:/var/www/vendor/
 
 volumes:
   ldap-data:
+  vendor:


### PR DESCRIPTION
The previous PR had two issues that are fixed here: 
- it was missing a volume mount for lang files
- it was creating files into local "vendor" directory which were useless (and owned by root in a Docker environment).
